### PR TITLE
Allow multi domains on workspace

### DIFF
--- a/backend/fief/repositories/workspace.py
+++ b/backend/fief/repositories/workspace.py
@@ -14,8 +14,7 @@ class WorkspaceRepository(BaseRepository[Workspace], UUIDRepositoryMixin[Workspa
     model = Workspace
 
     async def get_by_domain(self, domain: str) -> Optional[Workspace]:
-      
-        statement = select(Workspace).filter(Workspace.domain.like("%{}%".format(domain)))
+        statement = select(Workspace).filter(Workspace.domain.ilike(f"%{domain}%"))
         return await self.get_one_or_none(statement)
 
     async def get_main(self) -> Optional[Workspace]:

--- a/backend/fief/repositories/workspace.py
+++ b/backend/fief/repositories/workspace.py
@@ -14,7 +14,8 @@ class WorkspaceRepository(BaseRepository[Workspace], UUIDRepositoryMixin[Workspa
     model = Workspace
 
     async def get_by_domain(self, domain: str) -> Optional[Workspace]:
-        statement = select(Workspace).where(Workspace.domain == domain)
+      
+        statement = select(Workspace).filter(Workspace.domain.like("%{}%".format(domain)))
         return await self.get_one_or_none(statement)
 
     async def get_main(self) -> Optional[Workspace]:


### PR DESCRIPTION
I have an issue on the communication with fief server. Considering two containers: 

- **container 1**: fief server
- **container 2**: my container that comunicate with the fief admin server api 

On container 2, when trying the request to fief server, receive the error _CANT_DETERMINE_VALID_WORKSPACE_. 

```
curl --location --request GET 'http://fief-server:8000/admin/api/permissions?query=test:create' 
--header 'Authorization: Bearer **key**'
{"detail":"CANT_DETERMINE_VALID_WORKSPACE"}
```

The small PR solve my problem, and allow multi domains for one workspace.
