### PR TITLE
Whitelist redirect urls whose host ips are within private network ranges

### DIFF
--- a/fief/services/localhost.py
+++ b/fief/services/localhost.py
@@ -1,12 +1,16 @@
+import ipaddress
 import re
 
 LOCALHOST_HOST_PATTERN = re.compile(
-    r"([^\.]+\.)?localhost(\d+)?|127\.0\.0\.1", flags=re.IGNORECASE
+    r"([^\.]+\.)?localhost(\d+)?", flags=re.IGNORECASE
 )
 
 
 def is_localhost(host: str) -> bool:
-    return LOCALHOST_HOST_PATTERN.match(host) is not None
+    try:
+        return ipaddress.IPv4Address(host).is_private
+    except ValueError:
+        return LOCALHOST_HOST_PATTERN.match(host) is not None
 
 
 __all__ = ["is_localhost"]


### PR DESCRIPTION
According to the IANA specifications referenced in the [documentation](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address.is_private) of the official `ipaddress` library, the private network IP ranges seems to be well defined are shall be recognized across protocols.

Please let me know if this doesn't feel right.