### PR TITLE
added support for Docker secrets.

### DIFF
--- a/fief/settings.py
+++ b/fief/settings.py
@@ -124,7 +124,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        secrets_dir = '/run/secrets'
+        secrets_dir = "/run/secrets"
 
     @root_validator(pre=True)
     def parse_database_url(cls, values):

--- a/fief/settings.py
+++ b/fief/settings.py
@@ -32,6 +32,15 @@ class InvalidEncryptionKeyError(ValueError):
     pass
 
 
+class InitialSettings(BaseSettings):
+    secrets_dir : str = "/run/secrets"
+
+    class Config:
+        env_file = ".env"
+
+initial_settings = InitialSettings()        
+
+
 class Settings(BaseSettings):
     environment: Environment = Environment.PRODUCTION
     log_level: str = "INFO"
@@ -124,7 +133,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        secrets_dir = "/run/secrets"
+        secrets_dir = initial_settings.secrets_dir
 
     @root_validator(pre=True)
     def parse_database_url(cls, values):

--- a/fief/settings.py
+++ b/fief/settings.py
@@ -124,6 +124,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
+        secrets_dir = '/run/secrets'
 
     @root_validator(pre=True)
     def parse_database_url(cls, values):

--- a/fief/settings.py
+++ b/fief/settings.py
@@ -33,12 +33,13 @@ class InvalidEncryptionKeyError(ValueError):
 
 
 class InitialSettings(BaseSettings):
-    secrets_dir : str = "/run/secrets"
+    secrets_dir: str = "/run/secrets"
 
     class Config:
         env_file = ".env"
 
-initial_settings = InitialSettings()        
+
+initial_settings = InitialSettings()
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
This PR adds support for Docker secrets.

All environment variables can also be passed as Docker secrets.

To use docker secrets, for each Docker secret XXX, in a docker stack file we need to have lines like:
```
services:
  fief:
    image: ...
    secrets:
      - XXX

secrets:
    XXX:
      external: true
```

We also need to add the secret in the command line like:

`printf "my super secret password" | docker secret create XXX -`


