### PR TITLE
Fix for https://github.com/fief-dev/fief/issues/194

### DIFF
--- a/fief/repositories/authorization_code.py
+++ b/fief/repositories/authorization_code.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from sqlalchemy import select
 
@@ -16,7 +16,7 @@ class AuthorizationCodeRepository(
     async def get_valid_by_code(self, code: str) -> AuthorizationCode | None:
         statement = select(AuthorizationCode).where(
             AuthorizationCode.code == code,
-            AuthorizationCode.expires_at > datetime.now(timezone.utc),
+            AuthorizationCode.expires_at > datetime.now(timezone.utc) + timedelta(seconds=-1),
         )
         return await self.get_one_or_none(statement)
 


### PR DESCRIPTION
This commit adds 1 second tolerance to the `fief_authorization_codes.expires_at value`.
In the logs I see that the value `expires_at`, stored in `fief_authorization_codes` table, is sometimes a few milliseconds behind 'now'.
Example: 
  - expires_at: 2023-06-06 14:33:29.591862
  - now:           2023-06-06 14:33:29.824840
 Because of that `get_valid_by_code()` returns None and authorization fails.
 
 I don't know why, but this is reproducible on my side only after I access `/clients/{client_id}` REST API.