### PR TITLE
Sendgrid fix proposal

### DIFF
--- a/fief/services/email/sendgrid.py
+++ b/fief/services/email/sendgrid.py
@@ -24,8 +24,10 @@ class DomainDoesNotExistError(CreateDomainError):
 class Sendgrid(EmailProvider):
     DOMAIN_AUTHENTICATION = True
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, from_email: str = None, from_name: str = None) -> None:
         self._client = SendGridAPIClient(api_key=api_key)
+        self._from_email = from_email
+        self._from_name  = from_name
 
     def send_email(
         self,
@@ -36,7 +38,10 @@ class Sendgrid(EmailProvider):
         html: str | None = None,
         text: str | None = None,
     ):
-        from_email, from_name = sender
+        if self._from_email is not None:
+            from_email, from_name = self._from_email, self._from_name
+        else:
+            from_email, from_name = sender
         to_email, to_name = recipient
         try:
             message = Mail(

--- a/fief/services/email/smtp.py
+++ b/fief/services/email/smtp.py
@@ -1,4 +1,5 @@
 import smtplib
+import ssl
 from email.message import EmailMessage
 
 from fief.services.email.base import (
@@ -48,16 +49,13 @@ class SMTP(EmailProvider):
             if text is not None:
                 message.add_alternative(text, subtype="plain")
 
-            if self.ssl:
-                with smtplib.SMTP_SSL(self.host, self.port) as server:
-                    if self.username and self.password:
-                        server.login(self.username, self.password)
-                    server.send_message(message)
-            else:
-                with smtplib.SMTP(self.host, self.port) as server:
-                    if self.username and self.password:
-                        server.login(self.username, self.password)
-                    server.send_message(message)
+            with smtplib.SMTP(self.host, self.port) as server:
+                if self.ssl:
+                    context = ssl.create_default_context()
+                    server.starttls(context=context)
+                if self.username and self.password:
+                    server.login(self.username, self.password)
+                server.send_message(message)
         except smtplib.SMTPException as e:
             raise SendEmailError(str(e)) from e
 

--- a/fief/services/email/smtp.py
+++ b/fief/services/email/smtp.py
@@ -1,5 +1,4 @@
 import smtplib
-import ssl
 from email.message import EmailMessage
 
 from fief.services.email.base import (
@@ -49,13 +48,16 @@ class SMTP(EmailProvider):
             if text is not None:
                 message.add_alternative(text, subtype="plain")
 
-            with smtplib.SMTP(self.host, self.port) as server:
-                if self.ssl:
-                    context = ssl.create_default_context()
-                    server.starttls(context=context)
-                if self.username and self.password:
-                    server.login(self.username, self.password)
-                server.send_message(message)
+            if self.ssl:
+                with smtplib.SMTP_SSL(self.host, self.port) as server:
+                    if self.username and self.password:
+                        server.login(self.username, self.password)
+                    server.send_message(message)
+            else:
+                with smtplib.SMTP(self.host, self.port) as server:
+                    if self.username and self.password:
+                        server.login(self.username, self.password)
+                    server.send_message(message)
         except smtplib.SMTPException as e:
             raise SendEmailError(str(e)) from e
 


### PR DESCRIPTION
fixes https://github.com/fief-dev/fief/issues/272

how about this proposed change?
that we have the option to pass the from_email and from_name as config dict together with the api-key?

another way could be to make the default-from-email in the settings.py use an ENV parameter if set? what do you guys think?