### PR TITLE
add password_min_length and password_min_score to settings

### DIFF
--- a/fief/services/password.py
+++ b/fief/services/password.py
@@ -2,8 +2,8 @@ from typing import Self
 
 from zxcvbn_rs_py import zxcvbn
 
-from fief.settings import settings
 from fief.locale import gettext_lazy as _
+from fief.settings import settings
 
 MIN_PASSWORD_LENGTH = settings.password_min_length
 MAX_PASSWORD_LENGTH = 128

--- a/fief/services/password.py
+++ b/fief/services/password.py
@@ -2,11 +2,12 @@ from typing import Self
 
 from zxcvbn_rs_py import zxcvbn
 
+from fief.settings import settings
 from fief.locale import gettext_lazy as _
 
-MIN_PASSWORD_LENGTH = 8
+MIN_PASSWORD_LENGTH = settings.password_min_length
 MAX_PASSWORD_LENGTH = 128
-MIN_PASSWORD_STRENGTH_SCORE = 3
+MIN_PASSWORD_STRENGTH_SCORE = settings.password_min_score
 
 
 class PasswordValidation:

--- a/fief/settings.py
+++ b/fief/settings.py
@@ -137,7 +137,7 @@ class Settings(BaseSettings):
     fief_documentation_url: str = "https://docs.fief.dev"
 
     password_min_length: int = 8
-    password_min_score: int = 3
+    password_min_score: int = Field(ge=0, le=4, default=3)
 
     model_config = SettingsConfigDict(
         env_file=".env", extra="ignore", secrets_dir=initial_settings.secrets_dir

--- a/fief/settings.py
+++ b/fief/settings.py
@@ -136,6 +136,9 @@ class Settings(BaseSettings):
 
     fief_documentation_url: str = "https://docs.fief.dev"
 
+    password_min_length: int = 8
+    password_min_score: int = 3
+
     model_config = SettingsConfigDict(
         env_file=".env", extra="ignore", secrets_dir=initial_settings.secrets_dir
     )


### PR DESCRIPTION
This changes allows to configure lower password requirements.
As other fief settings, this can be overriden from .env file or environment like:
~~~
PASSWORD_MIN_LENGTH=6
PASSWORD_MIN_SCORE=1
~~~