### PR TITLE
Fix Password Reset Redirects

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:0-3.12
+FROM mcr.microsoft.com/devcontainers/python:3.12
 
 ENV PYTHONUNBUFFERED 1
 ENV HATCH_CONFIG /workspaces/fief/.devcontainer/hatch.config.toml

--- a/fief/apps/auth/routers/reset.py
+++ b/fief/apps/auth/routers/reset.py
@@ -21,6 +21,7 @@ from fief.services.user_manager import (
 
 router = APIRouter()
 
+
 @router.api_route("/forgot", methods=["GET", "POST"], name="reset:forgot")
 async def forgot_password(
     request: Request,

--- a/fief/apps/auth/routers/reset.py
+++ b/fief/apps/auth/routers/reset.py
@@ -21,7 +21,6 @@ from fief.services.user_manager import (
 
 router = APIRouter()
 
-
 @router.api_route("/forgot", methods=["GET", "POST"], name="reset:forgot")
 async def forgot_password(
     request: Request,
@@ -95,6 +94,11 @@ async def reset_password(
         else:
             if login_session is not None:
                 redirection = tenant.url_path_for(request, "auth:login")
+                return RedirectResponse(
+                    url=redirection, status_code=status.HTTP_302_FOUND
+                )
+            else:
+                redirection = tenant.url_path_for(request, "auth.dashboard:profile")
                 return RedirectResponse(
                     url=redirection, status_code=status.HTTP_302_FOUND
                 )

--- a/tests/test_apps_auth_reset.py
+++ b/tests/test_apps_auth_reset.py
@@ -181,7 +181,10 @@ class TestPostResetPassword:
             },
         )
 
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == status.HTTP_302_FOUND
+
+        redirect_uri = response.headers["Location"]
+        assert redirect_uri.endswith("/")
 
     async def test_valid_with_login_session(
         self,


### PR DESCRIPTION
Fixes #400.

Summary of changes:
- Updated devcontainer image to allow Codespaces to work
- Added redirect to Auth Dashboard Profile (which forces a redirect to the login page) after a password reset without a session
- Modified corresponding integration test
- Fixed pytest dependency shenanigans that caused *literally the entire test suite to break somehow*

NOTE: `pytest-asyncio==0.21.1` caused an error that resulted in `AttributeError: 'FixtureDef' object has no attribute 'unittest'`. According to [the associated Github Issue](https://github.com/pytest-dev/pytest/issues/12269), bumping to 0.21.2 (and, subsequently, pinning the `pytest` and `pytest-cov` versions) fixed the issue. 