### PR TITLE
Include htmx.org and hyperscript.org as part of javascript bundle.

### DIFF
--- a/fief/templates/admin/base.html
+++ b/fief/templates/admin/base.html
@@ -8,6 +8,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="icon" href="{{ url_for('dashboard:static', path='/favicon.svg') }}" />
       <link href="{{ url_for('dashboard:static', path='/admin.css') }}" rel="stylesheet">
+      <script src="{{ url_for('dashboard:static', path='/dependencies.bundle.js') }}"></script>
       {% block javascripts_modules %}{% endblock %}
       {% if posthog_api_key %}
         <script>

--- a/fief/templates/admin/base.html
+++ b/fief/templates/admin/base.html
@@ -8,8 +8,6 @@
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="icon" href="{{ url_for('dashboard:static', path='/favicon.svg') }}" />
       <link href="{{ url_for('dashboard:static', path='/admin.css') }}" rel="stylesheet">
-      <script src="https://unpkg.com/htmx.org@1.8.4"></script>
-      <script src="https://unpkg.com/hyperscript.org@0.9.7"></script>
       {% block javascripts_modules %}{% endblock %}
       {% if posthog_api_key %}
         <script>

--- a/fief/templates/auth/base.html
+++ b/fief/templates/auth/base.html
@@ -31,6 +31,7 @@
           }
         </style>
       {% endif %}
+      <script src="{{ url_for('auth:static', path='/dependencies.bundle.js') }}"></script>
       {% block javascripts_modules %}{% endblock %}
     {% endblock %}
   </head>

--- a/fief/templates/auth/base.html
+++ b/fief/templates/auth/base.html
@@ -31,8 +31,6 @@
           }
         </style>
       {% endif %}
-      <script src="https://unpkg.com/htmx.org@1.8.4"></script>
-      <script src="https://unpkg.com/hyperscript.org@0.9.7"></script>
       {% block javascripts_modules %}{% endblock %}
     {% endblock %}
   </head>

--- a/js/dependencies.mjs
+++ b/js/dependencies.mjs
@@ -1,0 +1,2 @@
+import * as htmx from 'htmx.org'
+import * as hyperscript from 'hyperscript.org'

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@uiw/codemirror-theme-github": "^4.21.21",
         "autoprefixer": "^10.4.17",
         "codemirror": "^6.0.1",
+        "htmx.org": "^1.9.12",
+        "hyperscript.org": "^0.9.12",
         "postcss": "^8.4.33",
         "rollup": "^3.29.4",
         "rollup-plugin-postcss": "^4.0.2",
@@ -1535,6 +1537,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/htmx.org": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.12.tgz",
+      "integrity": "sha512-VZAohXyF7xPGS52IM8d1T1283y+X4D+Owf3qY1NZ9RuBypyu9l8cGsxUMAG5fEAb/DhT7rDoJ9Hpu5/HxFD3cw==",
+      "license": "0BSD"
+    },
+    "node_modules/hyperscript.org": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/hyperscript.org/-/hyperscript.org-0.9.12.tgz",
+      "integrity": "sha512-fLtS+FVayzLUdgC4w00oozg0uickzUyJIbyKg0fB7vSGkUfsY2itGl/XsTcVFahufp41oN5OFFmRXMxoIZ97Og==",
+      "license": "BSD 2-Clause",
+      "dependencies": {
+        "markdown-it-deflist": "^2.1.0",
+        "terser": "^5.14.1"
+      },
+      "bin": {
+        "_hyperscript": "src/bin/node-hyperscript.js"
+      }
+    },
     "node_modules/icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -1743,6 +1764,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/markdown-it-deflist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
+      "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg==",
+      "license": "MIT"
     },
     "node_modules/mdn-data": {
       "version": "2.0.14",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@uiw/codemirror-theme-github": "^4.21.21",
     "autoprefixer": "^10.4.17",
     "codemirror": "^6.0.1",
+    "htmx.org": "^1.9.12",
+    "hyperscript.org": "^0.9.12",
     "postcss": "^8.4.33",
     "rollup": "^3.29.4",
     "rollup-plugin-postcss": "^4.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -156,4 +156,18 @@ module.exports = [
       terser(),
     ],
   },
+  {
+    input: './node_modules/htmx.org/dist/htmx.js',
+    output: {
+      file: './fief/static/htmx.bundle.js',
+      format: 'iife',
+    },
+  },
+    {
+    input: './node_modules/hyperscript.org/src/_hyperscript.js',
+    output: {
+      file: './fief/static/hyperscript.bundle.js',
+      format: 'iife',
+    },
+  },  
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -157,17 +157,14 @@ module.exports = [
     ],
   },
   {
-    input: './node_modules/htmx.org/dist/htmx.js',
+    input: './js/dependencies.mjs',
     output: {
-      file: './fief/static/htmx.bundle.js',
+      file: './fief/static/dependencies.bundle.js',
       format: 'iife',
     },
+    plugins: [
+      nodeResolve(),
+      terser(),
+    ],
   },
-    {
-    input: './node_modules/hyperscript.org/src/_hyperscript.js',
-    output: {
-      file: './fief/static/hyperscript.bundle.js',
-      format: 'iife',
-    },
-  },  
 ];


### PR DESCRIPTION
The Administration UI requires htmx.org and hyperscript.org
from unpkg.com. Without these packages, all htmx functions
on the UI break (e.g. adding redirect URIs). This commit attempts
to include these packages as part of the javascript bundle as
described in the Hypermedia Systems book:
https://hypermedia.systems/extending-html-as-hypermedia/