### PR TITLE
Add option for using docker volume for data persistence

### DIFF
--- a/fief/cli/quickstart.py
+++ b/fief/cli/quickstart.py
@@ -32,8 +32,8 @@ def add_commands(app: typer.Typer) -> typer.Typer:
             help="Whether the Fief server will be served over SSL. For local development, it'll likely be false.",
         ),
         use_docker_volume: bool = typer.Option(
-            False,
-            help="Store Fief server data in a Docker volume to ensure data persistence.",
+            True,
+            help="Store Fief server data in a Docker volume to ensure data persistence (ignored without `--docker`).",
         ),
     ):
         """Generate secrets and environment variables to help users getting started quickly."""

--- a/fief/cli/quickstart.py
+++ b/fief/cli/quickstart.py
@@ -31,6 +31,10 @@ def add_commands(app: typer.Typer) -> typer.Typer:
             False,
             help="Whether the Fief server will be served over SSL. For local development, it'll likely be false.",
         ),
+        use_docker_volume: bool = typer.Option(
+            False,
+            help="Store Fief server data in a Docker volume to ensure data persistence."
+        )
     ):
         """Generate secrets and environment variables to help users getting started quickly."""
 
@@ -88,6 +92,8 @@ def add_commands(app: typer.Typer) -> typer.Typer:
                 ],
                 "ghcr.io/fief-dev/fief:latest",
             ]
+            if use_docker_volume:
+                parts.append("-v 'fief_data:/data'")
             typer.echo(" \\\n  ".join(parts))
         else:
             for name, value in environment_variables.items():

--- a/fief/cli/quickstart.py
+++ b/fief/cli/quickstart.py
@@ -33,8 +33,8 @@ def add_commands(app: typer.Typer) -> typer.Typer:
         ),
         use_docker_volume: bool = typer.Option(
             False,
-            help="Store Fief server data in a Docker volume to ensure data persistence."
-        )
+            help="Store Fief server data in a Docker volume to ensure data persistence.",
+        ),
     ):
         """Generate secrets and environment variables to help users getting started quickly."""
 


### PR DESCRIPTION
### Motivation

Current docs provide two types of using Fief in projects:
1) [Local setup](https://docs.fief.dev/getting-started/local-instance/#1-start-your-local-fief-instance): single docker container
2) [Production setup](https://docs.fief.dev/self-hosting/) with reverse proxy and SSL setup

I think it will be useful to add `--use-docker-volume` option to quickstart command to provide complete command for local setup with persistence. Currently, the data is stored inside the container without using volumes, and while it technically will persist across container restart, using volume is more reliable way to persist data (e.g. across rebuilding Fief image).

I believe persistence can be useful in local setup.

### Docs improvements

If this PR will be accepted, the docs also should be edited to highlight this option. In fact, the docs now contain a bit of misleading information, as current setup doesn't persist data during container rebuilds:

> If you need to restart or recreate your container, you'll need to set the same secrets again.

Also, the default value for `DATABASE_LOCATION` in https://docs.fief.dev/self-hosting/environment-variables/ is stated is "Current working directory", while it's actually `/data/db` for Docker setup