### PR TITLE
fix: add missing zh_cn translations for i18n strings

### DIFF
--- a/fief/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/fief/locale/zh_CN/LC_MESSAGES/messages.po
@@ -272,158 +272,158 @@ msgstr "已停止注册"
 
 #: fief/apps/auth/forms/password.py:9
 msgid "Old password"
-msgstr ""
+msgstr "旧密码"
 
 #: fief/apps/auth/forms/password.py:19
 msgid "Confirm new password"
-msgstr ""
+msgstr "确认新密码"
 
 #: fief/apps/auth/routers/dashboard.py:128
 msgid "A user with this email address already exists."
-msgstr ""
+msgstr "已存在使用此电子邮件地址的用户。"
 
 #: fief/apps/auth/routers/dashboard.py:80
 msgid "Your profile has successfully been updated."
-msgstr ""
+msgstr "个人信息已成功更新。"
 
 #: fief/apps/auth/routers/dashboard.py:209
 msgid "Old password is invalid."
-msgstr ""
+msgstr "旧密码不正确。"
 
 #: fief/apps/auth/routers/dashboard.py:217
 msgid "Passwords don't match."
-msgstr ""
+msgstr "密码不一致。"
 
 #: fief/apps/auth/routers/dashboard.py:224
 msgid "Your password has been changed successfully."
-msgstr ""
+msgstr "密码已成功更新。"
 
 #: fief/apps/auth/routers/oauth.py:149
 msgid "An error occurred while querying the provider API. Original error message: %(message)s"
-msgstr ""
+msgstr "调用 provider API 时发生错误。原始错误信息为：%(message)s"
 
 #: fief/dependencies/auth.py:277
 msgid "Missing login session. You should return to %(tenant)s and try to login again"
-msgstr ""
+msgstr "缺少登录会话。请回到 %(tenant)s 并重新尝试登录。"
 
 #: fief/templates/auth/dashboard/index.html:7
 #: fief/templates/auth/dashboard/index.html:10
 #: fief/templates/auth/dashboard/sidebar.html:31
 msgid "Profile"
-msgstr ""
+msgstr "个人信息"
 
 #: fief/templates/auth/dashboard/index.html:43
 msgid "Update profile"
-msgstr ""
+msgstr "更新个人信息"
 
 #: fief/templates/auth/dashboard/password.html:10
 #: fief/templates/auth/dashboard/password.html:23
 msgid "Change password"
-msgstr ""
+msgstr "修改密码"
 
 #: fief/templates/auth/dashboard/sidebar.html:16
 msgid "Back to application"
-msgstr ""
+msgstr "返回应用程序"
 
 #. Shown in a small badge over a button. Keep it extra-short.
-#. 
+#.
 #. https://s3.eu-west-1.amazonaws.com/po-pub/i/oI8dlw8Cf6lS4C4fv0FByxXe.png
 #: fief/templates/auth/login.html:38
 msgid "Used last"
-msgstr ""
+msgstr "最后使用"
 
 #: fief/services/password.py:43
 msgid "Password is not strong enough."
-msgstr ""
+msgstr "密码强度不足。"
 
 #: fief/templates/macros/forms.html:307
 msgid "Weak"
-msgstr ""
+msgstr "弱"
 
 #: fief/templates/macros/forms.html:309
 msgid "Acceptable"
-msgstr ""
+msgstr "可"
 
 #: fief/templates/macros/forms.html:311
 msgid "Good"
-msgstr ""
+msgstr "佳"
 
 #: fief/services/password.py:26
 msgid "Password must be at least %(min)d characters long."
-msgstr ""
+msgstr "密码必须至少 %(min)d 个字符长度。"
 
 #: fief/services/password.py:34
 msgid "Password must be at most %(max)d characters long."
-msgstr ""
+msgstr "密码最多只能有 %(max)d 个字符长度。"
 
 #: fief/apps/auth/forms/profile.py:17
 msgid "Confirm your password"
-msgstr ""
+msgstr "确认你的密码"
 
 #: fief/apps/auth/forms/verify_email.py:8
 msgid "Verification code"
-msgstr ""
+msgstr "验证码"
 
 #: fief/apps/auth/routers/auth.py:239
 msgid "The verification code is invalid. Please check that you have entered it correctly. If the code was copied and pasted, ensure it has not expired. If it has been more than one hour, please request a new verification code."
-msgstr ""
+msgstr "验证码无效。请检查您是否正确输入。如果是复制粘贴的验证码，请确认尚未过期。如果验证码超过一小时以上，请重新请求验证码。"
 
 #: fief/apps/auth/routers/dashboard.py:117
 msgid "Your password is invalid."
-msgstr ""
+msgstr "密码无效。"
 
 #: fief/apps/auth/routers/dashboard.py:167
 msgid "The verification code is invalid. Please check that you have entered it correctly. If the code was copied and pasted, ensure it has not expired. If it has been more than one hour, start over the email change process."
-msgstr ""
+msgstr "验证码无效。请检查您是否正确输入。如果是复制粘贴的验证码，请确认尚未过期。如果验证码超过一小时以上，请重新开始电子邮件修改流程。"
 
 #: fief/templates/auth/verify_email.html:6
 #: fief/templates/auth/verify_email.html:8
 msgid "Verify your email"
-msgstr ""
+msgstr "验证您的电子邮件"
 
 #: fief/templates/auth/verify_email.html:29
 msgid "To complete the email verification process, please check your email for the verification code. Enter the code below to verify your email address."
-msgstr ""
+msgstr "要完成电子邮件验证，请检查您的电子邮件以获取验证码。请在下方输入该验证码以验证您的电子邮件地址。"
 
 #: fief/templates/auth/verify_email.html:33
 msgid "Resend the code"
-msgstr ""
+msgstr "重新发送验证码"
 
 #: fief/templates/auth/dashboard/email/verify.html:47
 #: fief/templates/auth/verify_email.html:34
 msgid "Verify my email"
-msgstr ""
+msgstr "验证我的电子邮件地址"
 
 #: fief/templates/auth/dashboard/index.html:12
 msgid "Email"
-msgstr ""
+msgstr "电子邮件"
 
 #: fief/templates/auth/dashboard/index.html:13
 msgid "Manage your email address to receive important updates and notifications."
-msgstr ""
+msgstr "管理您的电子邮件地址以接收重要的更新和通知。"
 
 #: fief/templates/auth/dashboard/index.html:23
 msgid "Change"
-msgstr ""
+msgstr "修改"
 
 #: fief/templates/auth/dashboard/index.html:29
 msgid "Profile information"
-msgstr ""
+msgstr "个人信息"
 
 #: fief/templates/auth/dashboard/index.html:30
 msgid "Manage your profile information."
-msgstr ""
+msgstr "管理您的个人信息。"
 
 #: fief/templates/auth/dashboard/email/change.html:21
 #: fief/templates/auth/dashboard/email/verify.html:45
 msgid "Cancel"
-msgstr ""
+msgstr "取消"
 
 #: fief/templates/auth/dashboard/email/change.html:23
 msgid "Change email address"
-msgstr ""
+msgstr "修改电子邮件地址"
 
 #: fief/templates/auth/dashboard/email/verify.html:30
 msgid "To complete the email change, please check your email for the verification code. Enter the code below to verify your new email address."
-msgstr ""
+msgstr "要完成电子邮件地址更改，请检查您的电子邮件以获取验证码。请在下方输入该验证码以验证您的新电子邮件地址。"
 


### PR DESCRIPTION
Found that some of the texts are not properly translated/i18ned within pages like User Profile/Change Password/etc. Hence offering a quick update on all the strings located in /fief/locale/zh_CN/LC_MESSAGES/messages.po